### PR TITLE
fix: restaurar index.html eliminado por error en PR previa

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,3 +21,5 @@ Este archivo se actualiza con cada Pull Request para registrar avances y correcc
   PR: [#7](https://github.com/ramiromarcosmorales/emiti-web/pull/7) - @ramiromarcosmorales (Coordinador / DevOps)
 
 ### Fixed
+- [feature/coordinador-setup-repo-and-pages] Restauración de `index.html` eliminado por error en PR prevía.
+  PR: [#9](https://github.com/ramiromarcosmorales/emiti-web/pull/9) - @ramiromarcosmorales (Coordinador / DevOps)


### PR DESCRIPTION
# 🟣 PULL REQUEST – Actividad Obligatoria N.º 1 – Programación Web I

---

## 📌 Datos del Estudiante

- **Nombre y Apellido:** Ramiro Marcos Morales
- **Número de Matrícula:** 149386
- **Carrera:** Tecnicatura Universitaria en Programación de Sistemas  
- **Materia:** Programación Web I  
- **Profesor:** Lic. Matías Velasquez  
- **Cuatrimestre/Año:** 2º Cuatrimestre / 2025  
- **Rol asignado para esta entrega:** Coordinador/DevOps

---

## 📂 Rama de trabajo

- **Nombre de la rama:** `feature/coordinador-setup-repo-and-pages`
---

## 📝 Descripción del trabajo realizado

Se restauró el archivo `index.html` que fue eliminado por un error en una PR previa, con el fin de mantener la estructura base del proyecto.

---

## 📄 Archivos modificados / agregados

- `index.html`  

---

## ✅ Checklist

- [x] Trabajé sobre una rama `feature/` creada a partir de `develop`
- [x] Realicé commits claros y explicativos
- [x] Completé mi sección asignada según el rol
- [x] Actualicé el archivo `changelog.md` con el resumen de esta PR
- [x] Solicité revisión al Coordinador/DevOps
- [x] La PR incluye solo cambios relacionados con mi tarea asignada

---

## 🧾 Enlace a la consigna

[📄 Consigna Actividad Obligatoria N.º 1 - GitHub](https://drive.google.com/file/d/1lPLkaGY_aazWc4rwl9bBFueHOvn1FsOA/view?usp=sharing )

---